### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
         }
     },
     "require": {
-        "illuminate/routing": "^5.5",
-        "illuminate/support": "^5.5"
+        "illuminate/routing": "5.5.*",
+        "illuminate/support": "5.5.*"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.5",


### PR DESCRIPTION
Laravel doesn't follow semver. So having `^5.x`, `5.*` or `>=5.x` will mean that composer will install a future version even though that version breaks the package.